### PR TITLE
Add initial .md file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # txt-to-HTML-converter
-A conversion tool made for converting txt file to standard HTML.
+A conversion tool made for converting .txt and .md files to standard HTML.
 
 The main purpose of this program is to create TIL (Today I learned) HTML files for blogging and personal purposes. A TIL can be pretty useful to anyone creating one as they can write down important things that they learned about and share it with others, or just keep it for themselves as something to reference. However, you can also use it as a simple txt to HTML converter. 
 

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,7 @@
+import re
+
+def parse_md(html_contents):
+    return re.sub(
+    r'\[(.+?)\]\(([^ ]+)\)', # Regex pattern to match .md link syntax and capture the text to display / the link
+    r'<a href=\2>\1</a>', # Replace all .md links with <a> tags with help from backreferences
+    html_contents)

--- a/helper.py
+++ b/helper.py
@@ -9,9 +9,10 @@ def parse_md(html_contents):
 
 def generate_duplicate_filename(output_dir, output_file):
     count = 2
-    while (os.path.exists(output_file)):
+    generated_filename = output_file
+    while (os.path.exists(generated_filename)):
         output_filename = os.path.splitext(os.path.basename(output_file))[0] + " (" + str(count) + ").html" 
-        output_file = os.path.join(output_dir, output_filename)
+        generated_filename = os.path.join(output_dir, output_filename)
         count = count + 1
-    
-    return output_file
+
+    return generated_filename

--- a/helper.py
+++ b/helper.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 def parse_md(html_contents):
@@ -5,3 +6,12 @@ def parse_md(html_contents):
     r'\[(.+?)\]\(([^ ]+)\)', # Regex pattern to match .md link syntax and capture the text to display / the link
     r'<a href=\2>\1</a>', # Replace all .md links with <a> tags with help from backreferences
     html_contents)
+
+def generate_duplicate_filename(output_dir, output_file):
+    count = 2
+    while (os.path.exists(output_file)):
+        output_filename = os.path.splitext(os.path.basename(output_file))[0] + " (" + str(count) + ").html" 
+        output_file = os.path.join(output_dir, output_filename)
+        count = count + 1
+    
+    return output_file

--- a/txt_to_html.py
+++ b/txt_to_html.py
@@ -1,10 +1,9 @@
 import argparse
 import os
-import re
 from shutil import rmtree
+from helper import parse_md
 
 VERSION = "0.1"
-
 
 def remove_output_dir(
         output_dir):  # function to remove output directory if it exists and make a new one regardless of if it exists or not
@@ -12,12 +11,6 @@ def remove_output_dir(
         rmtree(output_dir)  # using rmtree to delete the directory even if it has files in it
 
     os.makedirs(output_dir)  # Re/creating the output directory
-   
-def parse_md(html_contents):
-    return re.sub(
-    r'\[(.+?)\]\(([^ ]+)\)', # Regex pattern to match .md link syntax and capture the text to display / the link
-    r'<a href=\2>\1</a>', # Replace all .md links with <a> tags with help from backreferences
-    html_contents)
     
 def text_to_html(input_path, stylesheet, output_dir):
     try:

--- a/txt_to_html.py
+++ b/txt_to_html.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import re
 from shutil import rmtree
 
 VERSION = "0.1"
@@ -11,8 +12,13 @@ def remove_output_dir(
         rmtree(output_dir)  # using rmtree to delete the directory even if it has files in it
 
     os.makedirs(output_dir)  # Re/creating the output directory
-
-
+   
+def parse_md(html_contents):
+    return re.sub(
+    r'\[(.+?)\]\(([^ ]+)\)', # Regex pattern to match .md link syntax and capture the text to display / the link
+    r'<a href=\2>\1</a>', # Replace all .md links with <a> tags with help from backreferences
+    html_contents)
+    
 def text_to_html(input_path, stylesheet, output_dir):
     try:
         if os.path.exists(input_path) and os.path.isdir(input_path):  # if the user inputted a directory
@@ -55,6 +61,9 @@ def text_to_html(input_path, stylesheet, output_dir):
                         html_contents += "</p>\n"
 
                     html_contents += f"</body>\n</html>"
+                    
+                    if filename.endswith(".md"):
+                        html_contents = parse_md(html_contents)
 
                     with open(output_file, "w") as html:
                         html.write(html_contents)
@@ -93,6 +102,9 @@ def text_to_html(input_path, stylesheet, output_dir):
                 html_contents += "</p>\n"
 
             html_contents += f"</body>\n</html>"
+            
+            if input_path.endswith(".md"):
+                html_contents = parse_md(html_contents)
 
             with open(output_file, "w") as html:
                 html.write(html_contents)

--- a/txt_to_html.py
+++ b/txt_to_html.py
@@ -118,12 +118,12 @@ def text_to_html(input_path, stylesheet, output_dir):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Convert a text file to an HTML file.",
+    parser = argparse.ArgumentParser(description="Convert a text or markdown file to an HTML file.",
                                      epilog="Example: python txt_to_html.py input.txt or python txt_to_html.py ./folder")
 
     parser.add_argument("--version", "-v", action="version", version=f"%(prog)s {VERSION}")
 
-    parser.add_argument("input_path", help="Path to the input text file or directory")
+    parser.add_argument("input_path", help="Path to the input file or directory")
 
     # Optional argument to use the stylesheet feature
     parser.add_argument("--stylesheet", "-s", metavar="<link>",

--- a/txt_to_html.py
+++ b/txt_to_html.py
@@ -18,7 +18,7 @@ def text_to_html(input_path, stylesheet, output_dir):
         if os.path.exists(input_path) and os.path.isdir(input_path):  # if the user inputted a directory
             remove_output_dir(output_dir)
             for filename in os.listdir(input_path):
-                if filename.endswith(".txt"):
+                if filename.endswith(".txt") or filename.endswith(".md"):
 
                     input_file = os.path.join(input_path, filename)
                     output_file = os.path.splitext(os.path.basename(input_file))[0] + ".html"  # Constructing the output file's path based on the name of the input file
@@ -61,7 +61,7 @@ def text_to_html(input_path, stylesheet, output_dir):
 
             print("File conversion was successful! Please look for the ", output_dir, " folder.")
 
-        elif input_path.endswith(".txt") and os.path.isfile(input_path):
+        elif (input_path.endswith(".txt") or input_path.endswith(".md")) and os.path.isfile(input_path):
             remove_output_dir(output_dir)
 
             output_file = os.path.splitext(os.path.basename(input_path))[0] + ".html" # Constructing the output file's path based on the name of the input file

--- a/txt_to_html.py
+++ b/txt_to_html.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from shutil import rmtree
-from helper import parse_md
+from helper import *
 
 VERSION = "0.1"
 
@@ -22,6 +22,10 @@ def text_to_html(input_path, stylesheet, output_dir):
                     input_file = os.path.join(input_path, filename)
                     output_file = os.path.splitext(os.path.basename(input_file))[0] + ".html"  # Constructing the output file's path based on the name of the input file
                     output_file = os.path.join(output_dir, output_file)
+                    print(output_file)
+                    
+                    if os.path.exists(output_file):
+                        output_file = generate_duplicate_filename(output_dir, output_file)
 
                     # opening the input file
                     with open(input_file, "r") as txt:


### PR DESCRIPTION
txt-to-HTML-converter now supports the conversion of .md files.
Additionally, any markdown links are automatically converted to `<a> ... </a>` tags.
This addresses issue #6.

A new function (parse_md) was created for parsing markdown syntax. I made parse_md a function for futureproofing. If you ever decide to add more .md syntax support (such as support for italicizing or bolding), then you would only have to update the parse_md function.