### PR TITLE
Markdown Code block Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ You can also set a different output path of your generated file(s). To use type 
 
 These features can all be used together. For example `txt_to_html -o test -s https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css .\filename.txt` or `txt_to_html --output test --stylesheet https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css .\filename.txt `.
 
+# Markdown Features
+
+## Detecting Code Blocks
+The program is able to detect Markdown Code blocks like ``` `Hello World` ``` and convert to `<code> Hello World </code>` in HTML. 
+
 ### Additional Terminal Commands
 
 **Version** - To see the current version of the program you are running, type `txt_to_html -v` or `txt_tom_html --version` into your command line.

--- a/file_processors.py
+++ b/file_processors.py
@@ -54,10 +54,15 @@ def text_to_html(input_path, stylesheet, output_dir):
 
 
 def parse_md(html_contents):
-    return re.sub(
+
+    html_contents = re.sub(
     r'\[(.+?)\]\(([^ ]+)\)', # Regex pattern to match .md link syntax and capture the text to display / the link
     r'<a href=\2>\1</a>', # Replace all .md links with <a> tags with help from backreferences
     html_contents)
+
+    html_contents = re.sub(r"(`{1,3})(.*?)\1", r"<code>\2</code>", html_contents)
+
+    return html_contents
 
 def html_processor(input_file, stylesheet):
 


### PR DESCRIPTION
Added in support for Markdown code blocks as requested in issue #12 and update README to reflect the feature.