### PR TITLE
Ability to Convert --- from Markdown to <hr> tag in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ If you wanted to spice up the look of your generated HTML file(s) you are able t
 ## Changing the Default Output Path to a Specified one
 You can also set a different output path of your generated file(s). To use type `txt_to_html -o .\foldername filename.txt` or `txt_to_html --output .\foldername filename.txt` into your command line. This can also be done with folders instead of a single .txt or .md file.
 
+# Featues Available Only in Markdown
+
+## Code Blocks
+This program has the ability to detect Markdown code blocks and convert it the `<code>` tag in html. For example Markdown text that looks like this ``` `Hello World` ```, will show up like this `<code> Hello World </code>`.
+
+## Horizontal Rule
+If `---` is found in the Markdown file being converted. The program will convert it to the `<hr>` tag in HTML.
+
 These features can all be used together. For example `txt_to_html -o test -s https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css .\filename.txt` or `txt_to_html --output test --stylesheet https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css .\filename.txt `.
 
 ### Additional Terminal Commands

--- a/file_processors.py
+++ b/file_processors.py
@@ -55,10 +55,16 @@ def text_to_html(input_path, stylesheet, output_dir):
 
 
 def parse_md(html_contents):
-    return re.sub(
-    r'\[(.+?)\]\(([^ ]+)\)', # Regex pattern to match .md link syntax and capture the text to display / the link
-    r'<a href=\2>\1</a>', # Replace all .md links with <a> tags with help from backreferences
-    html_contents)
+    html_contents = re.sub(
+        r'\[(.+?)\]\(([^ ]+)\)',  # Regex pattern to match .md link syntax and capture the text to display / the link
+        r'<a href=\2>\1</a>',  # Replace all .md links with <a> tags with help from backreferences
+        html_contents)
+
+    html_contents = re.sub(r"(`{1,3})(.*?)\1", r"<code>\2</code>", html_contents)
+
+    html_contents = re.sub(r"---+", r"<hr>", html_contents)
+
+    return html_contents
 
 def html_processor(input_file, stylesheet):
 


### PR DESCRIPTION
Added in support to read horizontal rule in Markdown, as mentioned in issue #14. Also updated README to reflect this.